### PR TITLE
Downgrading graphql so that graphql-iso-date can be installed without --legacy-peer-deps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "dotenv": "^16.3.1"
+                "dotenv": "^16.3.1",
+                "graphql": "^14.7.0"
             },
             "devDependencies": {
                 "concurrently": "^8.2.0",
@@ -191,6 +192,17 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/graphql": {
+            "version": "14.7.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+            "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+            "dependencies": {
+                "iterall": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 6.x"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -208,6 +220,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/iterall": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
         },
         "node_modules/lodash": {
             "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "prettier": "^3.1.0"
     },
     "dependencies": {
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "graphql": "^14.7.0"
     }
 }


### PR DESCRIPTION
I added the graphql-iso-date node module so that we could work with ISO dates. Unfortunately this module depends on version 14 of the graphql node module. I forced graphql-iso-date to install and it seemed to work but to be on the safe side, I am going to downgrade graphql to version 14.7.0. Hopefully we don't need anything that was added from 14.7.0 to 16.8.1 which is the latest version.